### PR TITLE
Get started with kafka producer in API gateway

### DIFF
--- a/api-gateway/build.sbt
+++ b/api-gateway/build.sbt
@@ -2,6 +2,7 @@ val Http4sVersion = "0.20.17"
 val CirceVersion = "0.11.1"
 val Specs2Version = "4.1.0"
 val LogbackVersion = "1.2.3"
+//val KafkaVersion = "2.4.0"
 
 lazy val root = (project in file("."))
   .settings(
@@ -16,7 +17,8 @@ lazy val root = (project in file("."))
       "org.http4s"      %% "http4s-dsl"          % Http4sVersion,
       "io.circe"        %% "circe-generic"       % CirceVersion,
       "org.specs2"      %% "specs2-core"         % Specs2Version % "test",
-      "ch.qos.logback"  %  "logback-classic"     % LogbackVersion
+      "ch.qos.logback"  %  "logback-classic"     % LogbackVersion,
+      "org.apache.kafka" % "kafka-clients" % "2.4.0",
     ),
     addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.10.3"),
     addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.0")

--- a/api-gateway/src/main/scala/airavata/github/captivate/apigateway/ApigatewayServer.scala
+++ b/api-gateway/src/main/scala/airavata/github/captivate/apigateway/ApigatewayServer.scala
@@ -20,6 +20,8 @@ object ApigatewayServer {
   properties.put("key.serializer","org.apache.kafka.common.serialization.StringSerializer")
   properties.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer")
   properties.put("acks","all")
+  
+  // TODO: Close the producer gracefully when the server exits
   val producer = new KafkaProducer[String, String](properties)
 
   val topic = "test"

--- a/api-gateway/src/main/scala/airavata/github/captivate/apigateway/ApigatewayServer.scala
+++ b/api-gateway/src/main/scala/airavata/github/captivate/apigateway/ApigatewayServer.scala
@@ -1,5 +1,7 @@
 package airavata.github.captivate.apigateway
 
+import java.util.Properties
+
 import cats.effect.{ConcurrentEffect, ContextShift, Timer}
 import cats.implicits._
 import fs2.Stream
@@ -7,9 +9,20 @@ import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.implicits._
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.middleware.Logger
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+
 import scala.concurrent.ExecutionContext.global
 
 object ApigatewayServer {
+
+  val properties:Properties = new Properties()
+  properties.put("bootstrap.servers","localhost:9092")
+  properties.put("key.serializer","org.apache.kafka.common.serialization.StringSerializer")
+  properties.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer")
+  properties.put("acks","all")
+  val producer = new KafkaProducer[String, String](properties)
+
+  val topic = "test"
 
   def stream[F[_]: ConcurrentEffect](implicit T: Timer[F], C: ContextShift[F]): Stream[F, Nothing] = {
     for {
@@ -18,7 +31,7 @@ object ApigatewayServer {
       sessionAlg = SessionManagement.impl[F]
 
       httpApp = (
-        ApigatewayRoutes.userManagementRoute[F](userAlg) <+>
+        ApigatewayRoutes.userManagementRoute[F](userAlg, Some(producer)) <+>
         ApigatewayRoutes.sessionRoute[F](sessionAlg)
       ).orNotFound
 

--- a/api-gateway/src/test/scala/airavata/github/captivate/apigateway/ApiGatewaySpec.scala
+++ b/api-gateway/src/test/scala/airavata/github/captivate/apigateway/ApiGatewaySpec.scala
@@ -19,7 +19,7 @@ class ApiGatewaySpec extends org.specs2.mutable.Specification {
   private[this] val retGreeting: Response[IO] = {
     val getHW = Request[IO](Method.GET, uri"/usermanagement/Adithya")
     val userGreetings = UserManagement.impl[IO]
-    ApigatewayRoutes.userManagementRoute(userGreetings).orNotFound(getHW).unsafeRunSync()
+    ApigatewayRoutes.userManagementRoute(userGreetings, None).orNotFound(getHW).unsafeRunSync()
   }
 
   private[this] def uriReturns200(): MatchResult[Status] =


### PR DESCRIPTION
Relates to #20 and #10 .

Adding a simple Kafka producer to api server. To check this you can start kafka broker and start the service and the send GET request to `localhost:8080/usermanagement/<message>` to publish the message to the `test` topic 

**Tasks**
- [x] Use apache kafka client library to implement producer.
- [x] Publish a sample message to `test` topic.
- [x] Verify if the message is received by using a consumer example