### PR TITLE
Fix api gateway to handle data retrieval

### DIFF
--- a/api-gateway/src/main/scala/airavata/github/captivate/apigateway/ApigatewayServer.scala
+++ b/api-gateway/src/main/scala/airavata/github/captivate/apigateway/ApigatewayServer.scala
@@ -34,7 +34,8 @@ object ApigatewayServer {
 
       httpApp = (
         ApigatewayRoutes.userManagementRoute[F](userAlg, Some(producer)) <+>
-        ApigatewayRoutes.sessionRoute[F](sessionAlg)
+        ApigatewayRoutes.sessionRoute[F](sessionAlg) <+>
+        ApigatewayRoutes.dataRetrievalRoute(Some(producer))
       ).orNotFound
 
       // With Middlewares in place

--- a/api-gateway/src/main/scala/airavata/github/captivate/apigateway/DataRetrieval.scala
+++ b/api-gateway/src/main/scala/airavata/github/captivate/apigateway/DataRetrieval.scala
@@ -1,0 +1,22 @@
+package airavata.github.captivate.apigateway
+
+import airavata.github.captivate.apigateway.SessionManagement.Session
+import cats.Applicative
+import cats.effect.Sync
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import org.http4s.{EntityDecoder, EntityEncoder}
+import org.http4s.circe.{jsonEncoderOf, jsonOf}
+
+// TODO: Use later to decode message and validate
+
+case class DataRetrieval(locationid: String, startdate: String, enddate: String)
+
+object DataRetrieval {
+  implicit val dataRetrievalDecoder: Decoder[DataRetrieval] = deriveDecoder[DataRetrieval]
+  implicit def dataRetrievalEntityDecoder[F[_]: Sync]: EntityDecoder[F, DataRetrieval] =
+    jsonOf
+  implicit val dataRetrievalEncoder: Encoder[DataRetrieval] = deriveEncoder[DataRetrieval]
+  implicit def dataRetrievalEntityEncoder[F[_]: Applicative]: EntityEncoder[F, DataRetrieval] =
+    jsonEncoderOf
+}

--- a/api-gateway/src/test/scala/airavata/github/captivate/apigateway/ApiGatewaySpec.scala
+++ b/api-gateway/src/test/scala/airavata/github/captivate/apigateway/ApiGatewaySpec.scala
@@ -55,8 +55,8 @@ class ApiGatewaySpec extends org.specs2.mutable.Specification {
   }
 
   private[this] val retData: Response[IO] = {
-    val getHW = Request[IO](Method.GET, uri"/data-retrieval")
-    ApigatewayRoutes.dataRetrievalRoute[IO]().orNotFound(getHW).unsafeRunSync()
+    val getHW = Request[IO](Method.POST, uri"/data-retrieval")
+    ApigatewayRoutes.dataRetrievalRoute[IO](None).orNotFound(getHW).unsafeRunSync()
   }
 
   private[this] val retPredict: Response[IO] = {


### PR DESCRIPTION
This PR fixes API gateway have a POST api and receive the job message object and then pass it the data-retrieval topic.

**Tasks**
- [x] Add post api and send message
- [x] Test if message was received in data-retrieval service

*Way to Test*

send post request to `localhost:8080/data-retrieval` with body of format 
```
{"locationid":"ZIP:28801", "startdate": "2019-11-11", "enddate": "2019-11-11"}
```
to make data retrieval service to receive a message and fetch data

relates to #10 