### PR TITLE
Fix Mongo containter names in READMEs

### DIFF
--- a/data-retrieval/README.md
+++ b/data-retrieval/README.md
@@ -4,7 +4,7 @@ Dependencies:
 
 TODO: Evolve the readme as you develop specifically
 
-1. A Running kafka broker at `localhost:9092` with topic `test`.
+1. A Running kafka broker at `localhost:9092` with topic `data-retrieval`.
 
 2. `Python 3` - [https://www.python.org/downloads/] (https://www.python.org/downloads/).
 
@@ -19,7 +19,7 @@ pip3 install requests
 4. start Mongo container using
 
 ```
-docker run -d -p 27014-27016:27017-27019 --name mongodb2 mongo:4.0.4
+docker run -d -p 27014-27016:27017-27019 --name dataretrievaldb mongo:4.0.4
 ```
 
 if you do not have mongo image already pull it from docker repo using

--- a/model-execution/README.md
+++ b/model-execution/README.md
@@ -4,7 +4,7 @@ Dependencies:
 
 TODO: Evolve the readme as you develop specifically
 
-1. A Running kafka broker at `localhost:9092` with topic `test`.
+1. A Running kafka broker at `localhost:9092` with topic `model-execution`.
 
 2. `Python 3` - [https://www.python.org/downloads/] (https://www.python.org/downloads/).
 
@@ -18,7 +18,7 @@ pip3 install pymongo
 4. start Mongo container using
 
 ```
-docker run -d -p 27017-27019:27017-27019 --name mongodb1 mongo:4.0.4
+docker run -d -p 27017-27019:27017-27019 --name modelexecutiondb mongo:4.0.4
 ```
 
 if you do not have mongo image already pull it from docker repo using

--- a/postprocessing-analysis/README.md
+++ b/postprocessing-analysis/README.md
@@ -4,6 +4,8 @@ Requirements:
 
 1. To Run Kafka follow instructions from Readme file from Kafka.
 
+2. Make sure that you have a kafka broker running at `localhost:9092` with topic `postpostprocessing-analysis`
+
 2. Python 3 : [https://www.python.org/downloads/]
 
 3. kafka-python ```pip install kafka-python``` and pymongo from ```pip install pymongo```
@@ -11,7 +13,7 @@ Requirements:
 4. start Mongo container using
 
 ```
-docker run -d -p 27020-27022:27017-27019 --name mongodb3 mongo:4.0.4
+docker run -d -p 27020-27022:27017-27019 --name ppadb mongo:4.0.4
 ```
 
 if you do not have mongo image already pull it from docker repo using
@@ -20,11 +22,8 @@ if you do not have mongo image already pull it from docker repo using
 docker pull mongo:4.0.4
 ```
 
+Running the project
 
-Running:
-
-```python postprocessing-analysis.py```
-
-#Producer is just for test purpose will be removed as service evolves.
-To test with producer run producer at python producer.py
-
+```
+python3 postprocessing-analysis.py
+```

--- a/session-management/README.md
+++ b/session-management/README.md
@@ -4,24 +4,26 @@ Requirements:
 1. Install Nodejs and npm package (can be installed from https://nodejs.org/en/ any version greater than 9. Follow the instructions to download nodejs and npm)
 ------------
 
+2. A Running kafka broker at `localhost:9092` with topics `sessionmanagement` and `session-update`.
+
 3. Start MongoDB container using
 
 ```
-docker run -d -p 27023-27025:27017-27019 --name mongodb3 mongo:4.0.4
+docker run -d -p 27023-27025:27017-27019 --name sessionmanagementDB mongo:4.0.4
 ```
 
-2.Run the command
+4.Run the command
 ```sh
 npm install
 ```
 
 
-3.Now run the command
+5.Now run the command
 ```sh
 npm start
 ```
 
-4. Now you will be able to access the service through
+6. Now you will be able to access the service through
 ```
 http://localhost:3005/
 ```


### PR DESCRIPTION
Relates to #44 

This PR fixes the README files in the individual services and as they mangodb container names were repeated in multiple services leading to error. Also fixes minor bugs in README

- [x] Fix readme across all the services