### PR TITLE
Fix status field in message 

### DIFF
--- a/data-retrieval/data-retrieval.py
+++ b/data-retrieval/data-retrieval.py
@@ -63,7 +63,7 @@ while True:
                 "job_id": weather_req['job_id'],
                 "location_id": weather_req['location_id'],
                 "date": weather_req['date'],
-                "status": weather_req['status'],
+                "status": "Done",
                 # Number of fields will improve
                 "tmax": tmax[0]['value'],
                 "tmin": tmin[0]['value']


### PR DESCRIPTION
fixes #73 

The issue was caused since the processing services did not update the status field in the message .

![cap-fix](https://user-images.githubusercontent.com/1871941/74608489-7cb5a780-50af-11ea-8ed2-6a0b117ca068.png)

the last job created after fix